### PR TITLE
Additional keyboard based trajectory controller code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Clone the open-source repository.
 
 ```git clone https://github.com/caochao39/aerial_navigation_development_environment.git```
 
+Additionally install Pygame(to control uav from keyboard)
+
+```python3 -m pip install -U pygame --user```
+
 In a terminal, go to the folder and compile.
 
 
@@ -50,6 +54,12 @@ In another terminal,
 ```rostopic echo /joy```
 
 Press any button on the controller and joystick messages should display in the terminal.
+
+Incase running with keyboard, run the python code in '/src/keyboard_trajectory_controller'.
+
+```cd /src/keyboard_trajectory_controller```
+
+```python3 keyboard_trajectory_controller.py```
 
 ## Quick Start with Gazebo Simulator
 

--- a/src/keyboard_trajectory_controller/keyboard_trajectory_controller.py
+++ b/src/keyboard_trajectory_controller/keyboard_trajectory_controller.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+ 
+import rospy
+import pygame
+from geometry_msgs.msg import TwistStamped
+ 
+pygame.init()
+screen = pygame.display.set_mode((400, 300))
+ 
+rospy.init_node('twist_publisher')
+ 
+# Create a publisher object
+pub = rospy.Publisher('/attitude_control', TwistStamped, queue_size=10)
+ 
+# Set the initial message values
+twist_stamped_msg = TwistStamped()
+twist_stamped_msg.header.frame_id = "vehicle"
+twist_stamped_msg.twist.linear.x = 0.0
+twist_stamped_msg.twist.linear.y = 0.0
+twist_stamped_msg.twist.linear.z = 0.0
+twist_stamped_msg.twist.angular.x = 0.0
+twist_stamped_msg.twist.angular.y = 0.0
+twist_stamped_msg.twist.angular.z = 0.0
+ 
+while not rospy.is_shutdown():
+    # Handle events
+    for event in pygame.event.get():
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_q:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.angular.z = 1.0
+            if event.key == pygame.K_e:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.angular.z = -1.0
+ 
+            if event.key == pygame.K_w:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.y = 0.5
+ 
+            if event.key == pygame.K_s:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.y = -0.5
+ 
+            if event.key == pygame.K_a:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.x = -0.5
+ 
+            if event.key == pygame.K_d:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.x = 0.5
+ 
+            if event.key == pygame.K_z:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.z = 0.5
+ 
+            if event.key == pygame.K_x:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.z = -0.5
+ 
+ 
+        elif event.type == pygame.KEYUP:
+            if event.key == pygame.K_q:
+                # Set angular z back to 0.0 when q key is released
+                twist_stamped_msg.twist.angular.z = 0.0
+            if event.key == pygame.K_e:
+                # Set angular z back to 0.0 when q key is released
+                twist_stamped_msg.twist.angular.z = 0.0
+            if event.key == pygame.K_w:
+                # Set angular z back to 0.0 when q key is released
+                twist_stamped_msg.twist.linear.y = 0.0
+            if event.key == pygame.K_s:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.y = 0.0
+ 
+            if event.key == pygame.K_a:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.x = 0.0
+ 
+            if event.key == pygame.K_d:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.x = 0.0
+ 
+            if event.key == pygame.K_z:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.z = 0.0
+ 
+            if event.key == pygame.K_x:
+                # Set angular z to 2.0 when q key is pressed
+                twist_stamped_msg.twist.linear.z = 0.0
+         
+            elif event.key == pygame.K_ESCAPE:
+                pygame.quit()
+                exit()
+ 
+    # Publish the message if the angular.z value is not 0.0
+    if twist_stamped_msg.twist.angular.z != 0.0:
+        twist_stamped_msg.header.stamp = rospy.Time.now()
+        pub.publish(twist_stamped_msg)
+ 
+    if twist_stamped_msg.twist.linear.x != 0.0:
+        twist_stamped_msg.header.stamp = rospy.Time.now()
+        pub.publish(twist_stamped_msg)
+ 
+    if twist_stamped_msg.twist.linear.y != 0.0:
+        twist_stamped_msg.header.stamp = rospy.Time.now()
+        pub.publish(twist_stamped_msg)
+ 
+    if twist_stamped_msg.twist.linear.z != 0.0:
+        twist_stamped_msg.header.stamp = rospy.Time.now()
+        pub.publish(twist_stamped_msg)
+ 
+    # Wait for a small amount of time to avoid using too much CPU
+    pygame.time.wait(10)


### PR DESCRIPTION
Hi!

I've added a simple pygame based keyboard trajectory controller to run the simulation using keyboard keys. For manual control while testing any trajectory planner/ navigation package without joystick. (Running on WSL etc).

Also added instructions for running in Readme.md